### PR TITLE
Add 'files' field in package.json for distribution files inclusion

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "bin": {
     "joplin-cli": "dist/index.js"
   },
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "test": "jest",
     "build": "tsc"


### PR DESCRIPTION
Include the 'files' field in package.json to ensure distribution files are properly included when installing from GitHub. This change addresses the installation issue reported in issue #13.